### PR TITLE
Bluetooth: Do not send Pairing cancel intent during ACL disconnection

### DIFF
--- a/src/com/android/bluetooth/btservice/RemoteDevices.java
+++ b/src/com/android/bluetooth/btservice/RemoteDevices.java
@@ -358,12 +358,6 @@ final class RemoteDevices {
             }
             debugLog("aclStateChangeCallback: State:Connected to Device:" + device);
         } else {
-            if (device.getBondState() == BluetoothDevice.BOND_BONDING) {
-                /*Broadcasting PAIRING_CANCEL intent as well in this case*/
-                intent = new Intent(BluetoothDevice.ACTION_PAIRING_CANCEL);
-                intent.putExtra(BluetoothDevice.EXTRA_DEVICE, device);
-                mAdapterService.sendBroadcast(intent, mAdapterService.BLUETOOTH_PERM);
-            }
             if ((state == BluetoothAdapter.STATE_BLE_ON || state == BluetoothAdapter.STATE_BLE_TURNING_OFF) &&
                 (mBleOnDevices.contains(device))) {
                 intent = new Intent(BluetoothAdapter.ACTION_BLE_ACL_DISCONNECTED);


### PR DESCRIPTION
Add change to not send pairing cancel intent after acl disconnection
as this case is already handled in stack.

CRs-fixed: 946072

Change-Id: I0a3abc2bffe09bb48d042664e1edf017a8fa3fcd